### PR TITLE
feat: add dockerfile for docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*
+!Cargo.toml
+!Cargo.lock
+!src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Step 1: Build the binary using the official Rust image
+FROM rust:alpine AS builder
+RUN apk add --no-cache musl-dev git ca-certificates
+RUN rustup target add x86_64-unknown-linux-musl
+
+WORKDIR /usr/src/vandelay
+COPY . .
+
+# Create a minimal passwd file containing ONLY the 'nobody' user
+RUN echo "nobody:x:65534:65534:nobody:/:/sbin/nologin" > /etc/passwd.minimal
+
+# Force a fully static, release compilation targeting musl
+RUN RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target x86_64-unknown-linux-musl
+
+RUN chmod +x /usr/src/vandelay/target/x86_64-unknown-linux-musl/release/vandelay
+# Step 2: Copy the binary into a tiny, secure, stateless image
+FROM scratch
+COPY --from=builder /usr/src/vandelay/target/x86_64-unknown-linux-musl/release/vandelay /vandelay
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /etc/passwd.minimal /etc/passwd
+USER nobody
+ENTRYPOINT ["/vandelay"]


### PR DESCRIPTION
I want to be able to run vandelay inside docker. It'd be nice to have automated docker builds.

I believe this build is quite clean:
- runs as user nobody
- contains only the required files in the final image

I could further improve the PR by adding automated builds via github actions. 

Edit: 
I'm not familiar with rust, I used the build command from the readme combine with some help from Gemini. The `Dockerfile` is clean, but the build command should be double checked.

For a CI we could simply take the build artifact from the correct job: https://github.com/stalwartlabs/vandelay/actions/runs/29196696241/job/86660873965 and add it to a `Dockerfile`. This would mean we add a separate dockerfile for CI builds.


