### PR TITLE
Add `--repair-text-hash` to fix stale BLAKE3 hashes after manual archive edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ All actions accept a set of global flags (verbosity, worker pool size, retry pol
 | `-q, --quiet` | Warnings and errors only. |
 | `--max-retries <N>` | Max retries per request on transient failures (default 5). |
 | `--allow-invalid-certs` | Accept self-signed / invalid TLS certs. |
+| `--repair-text-hash` | Re-hash blobs hand-edited outside vandelay (e.g. a raw SQL `UPDATE` against the archive) before syncing. Off by default. |
 
 Credentials should be supplied via the `VANDELAY_PASSWORD` / `VANDELAY_TOKEN` / `VANDELAY_EWS_CLIENT_SECRET` / `VANDELAY_GRAPH_TOKEN` environment variables, or via an interactive prompt; passing them on the command line is supported but not recommended.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -123,6 +123,21 @@ struct GlobalArgs {
 
     #[arg(long, help = "Accept self-signed / invalid TLS certificates")]
     allow_invalid_certs: bool,
+
+    #[arg(
+        long,
+        help = "Re-hash blobs hand-edited outside vandelay before syncing",
+        long_help = "Re-hash blobs hand-edited outside vandelay before syncing.\n\
+            The archive is content-addressed: each blob's id is derived from a \
+            BLAKE3 hash of its bytes. A raw SQL edit against the archive (e.g. \
+            patching a sieve script with an UPDATE statement) changes the bytes \
+            without updating that hash, and also leaves SQLite's `data` column \
+            with TEXT storage class instead of BLOB — vandelay's own writes \
+            never do that, so it's used as the marker for rows to re-hash. \
+            Off by default because this rewrites archive rows before anything \
+            else touches them."
+    )]
+    repair_text_hash: bool,
 }
 
 #[derive(Args)]
@@ -530,7 +545,7 @@ fn resolve_import(source: Source) -> Result<Action, Error> {
 }
 
 fn resolve_managesieve_import(args: ManageSieveImportArgs) -> Result<Action, Error> {
-    let common = common_config(&args.global, args.archive);
+    let common = common_config(&args.global, args.archive)?;
     let auth = resolve_managesieve_auth(
         args.auth_basic.as_deref(),
         args.auth_password.as_deref(),
@@ -636,7 +651,7 @@ pub struct MaildirImportArgs {
 }
 
 fn resolve_maildir_import(args: MaildirImportArgs) -> Result<Action, Error> {
-    let common = common_config(&args.global, args.archive);
+    let common = common_config(&args.global, args.archive)?;
     if !args.folder.is_empty() && (!args.include.is_empty() || !args.exclude.is_empty()) {
         return Err(Error::Usage(
             "--folder is mutually exclusive with --include/--exclude".to_owned(),
@@ -686,7 +701,7 @@ pub struct TakeoutImportArgs {
 }
 
 fn resolve_takeout_import(args: TakeoutImportArgs) -> Result<Action, Error> {
-    let common = common_config(&args.global, args.archive);
+    let common = common_config(&args.global, args.archive)?;
     Ok(Action::ImportTakeout(
         common,
         TakeoutImportConfig {
@@ -698,7 +713,7 @@ fn resolve_takeout_import(args: TakeoutImportArgs) -> Result<Action, Error> {
 }
 
 fn resolve_dav_import(args: DavImportArgs, kind: DavKindArg) -> Result<Action, Error> {
-    let common = common_config(&args.global, args.archive);
+    let common = common_config(&args.global, args.archive)?;
     let auth = resolve_dav_auth(
         args.auth_basic.as_deref(),
         args.auth_password.as_deref(),
@@ -745,7 +760,7 @@ fn resolve_dav_auth(
 }
 
 fn resolve_jmap_import(args: JmapImportArgs) -> Result<Action, Error> {
-    let common = common_config(&args.global, args.archive);
+    let common = common_config(&args.global, args.archive)?;
     let auth = resolve_auth(
         args.auth_basic.as_deref(),
         args.auth_password.as_deref(),
@@ -769,7 +784,7 @@ fn resolve_jmap_import(args: JmapImportArgs) -> Result<Action, Error> {
 }
 
 fn resolve_imap_import(args: ImapImportArgs) -> Result<Action, Error> {
-    let common = common_config(&args.global, args.archive);
+    let common = common_config(&args.global, args.archive)?;
     let auth = resolve_imap_auth(
         args.auth_basic.as_deref(),
         args.auth_password.as_deref(),
@@ -850,7 +865,7 @@ fn resolve_imap_auth(
 }
 
 fn resolve_export(args: ExportArgs) -> Result<Action, Error> {
-    let common = common_config(&args.global, args.archive);
+    let common = common_config(&args.global, args.archive)?;
     let auth = resolve_auth(
         args.auth_basic.as_deref(),
         args.auth_password.as_deref(),
@@ -998,7 +1013,7 @@ pub struct ExchangeEwsImportArgs {
 
 fn resolve_exchange_ews_import(args: ExchangeEwsImportArgs) -> Result<Action, Error> {
     let archive = args.archive.clone();
-    let common = common_config(&args.global, archive);
+    let common = common_config(&args.global, archive)?;
     let mailbox_kind = match args.mailbox_kind.as_str() {
         "primary" => MailboxKind::Primary,
         "archive" => MailboxKind::Archive,
@@ -1195,7 +1210,7 @@ fn parse_event_body_format(s: &str) -> Result<EventBodyFormat, String> {
 }
 
 fn resolve_exchange_graph_import(args: ExchangeGraphImportArgs) -> Result<Action, Error> {
-    let common = common_config(&args.global, args.archive.clone());
+    let common = common_config(&args.global, args.archive.clone())?;
     let mailbox_kind = args.mailbox_kind;
     let event_body_format = args.event_body_format;
     let auth = resolve_graph_auth(
@@ -1253,20 +1268,24 @@ fn resolve_graph_auth(
     })
 }
 
-fn common_config(global: &GlobalArgs, archive: PathBuf) -> CommonConfig {
+fn common_config(global: &GlobalArgs, archive: PathBuf) -> Result<CommonConfig, Error> {
+    if global.repair_text_hash {
+        let conn = crate::db::init::open(&archive)?;
+        crate::db::blobs::repair_stale_hashes(&conn)?;
+    }
     let threads = global
         .threads
         .filter(|n| *n > 0)
         .unwrap_or_else(num_cpus::get)
         .max(1);
-    CommonConfig {
+    Ok(CommonConfig {
         archive,
         threads,
         dry_run: global.dry_run,
         max_retries: global.max_retries,
         allow_invalid_certs: global.allow_invalid_certs,
         logger: Logger::from_flags(global.quiet, global.verbose),
-    }
+    })
 }
 
 fn resolve_auth(

--- a/src/db/blobs.rs
+++ b/src/db/blobs.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{Connection, ErrorCode, OptionalExtension, Row, params, types::ValueRef};
 
 pub fn intern_blob(conn: &Connection, bytes: &[u8]) -> Result<i64, rusqlite::Error> {
     let hash = blake3::hash(bytes);
@@ -20,11 +20,66 @@ pub fn intern_blob(conn: &Connection, bytes: &[u8]) -> Result<i64, rusqlite::Err
     )
 }
 
+// `data` is declared BLOB, but SQLite is dynamically typed: a raw SQL UPDATE
+// using a text function (e.g. replace()) on this column stores the result
+// with TEXT storage class instead of BLOB. Accept either.
+fn column_bytes(row: &Row, idx: usize, name: &str) -> Result<Vec<u8>, rusqlite::Error> {
+    match row.get_ref(idx)? {
+        ValueRef::Blob(b) => Ok(b.to_vec()),
+        ValueRef::Text(t) => Ok(t.to_vec()),
+        other => Err(rusqlite::Error::InvalidColumnType(
+            idx,
+            name.to_owned(),
+            other.data_type(),
+        )),
+    }
+}
+
 pub fn blob_bytes(conn: &Connection, id: i64) -> Result<Option<Vec<u8>>, rusqlite::Error> {
     conn.query_row("SELECT data FROM blobs WHERE id = ?1", params![id], |row| {
-        row.get(0)
+        column_bytes(row, 0, "data")
     })
     .optional()
+}
+
+fn is_unique_violation(err: &rusqlite::Error) -> bool {
+    matches!(
+        err,
+        rusqlite::Error::SqliteFailure(f, _) if f.code == ErrorCode::ConstraintViolation
+    )
+}
+
+/// Recomputes the BLAKE3 hash for any blob row that was touched by a raw SQL
+/// edit outside vandelay (e.g. `UPDATE blobs SET data = replace(data, ...)`
+/// to hand-patch a sieve script). SQLite stores such a row's `data` with TEXT
+/// storage class even though the column is declared BLOB, which is how a
+/// legitimate vandelay write (always bound as a `Vec<u8>` parameter) never
+/// looks — so that's the marker used to find rows whose stored hash may no
+/// longer match their content. Rewriting hash+data together also restores
+/// proper BLOB storage class. Rows whose recomputed hash collides with an
+/// existing blob are left untouched (stale hash) for manual resolution,
+/// rather than failing the whole archive open.
+pub fn repair_stale_hashes(conn: &Connection) -> Result<usize, rusqlite::Error> {
+    let candidates: Vec<(i64, Vec<u8>)> = {
+        let mut stmt = conn.prepare("SELECT id, data FROM blobs WHERE typeof(data) = 'text'")?;
+        stmt.query_map([], |row| Ok((row.get(0)?, column_bytes(row, 1, "data")?)))?
+            .collect::<Result<_, _>>()?
+    };
+
+    let mut repaired = 0usize;
+    for (id, data) in candidates {
+        let hash = blake3::hash(&data);
+        let result = conn.execute(
+            "UPDATE blobs SET hash = ?1, data = ?2 WHERE id = ?3",
+            params![hash.as_bytes().as_slice(), data, id],
+        );
+        match result {
+            Ok(_) => repaired += 1,
+            Err(e) if is_unique_violation(&e) => continue,
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(repaired)
 }
 
 pub fn blob_len(conn: &Connection, id: i64) -> Result<Option<u64>, rusqlite::Error> {
@@ -87,6 +142,85 @@ mod tests {
             Some(&b"payload"[..])
         );
         assert_eq!(blob_bytes(&c, 9999).unwrap(), None);
+    }
+
+    #[test]
+    fn blob_bytes_tolerates_text_storage_class() {
+        // A raw SQL UPDATE using a text function (e.g. replace()) on the
+        // `data` column stores its result as TEXT storage class even though
+        // the column is declared BLOB — SQLite doesn't coerce it back.
+        let c = mem();
+        let id = intern_blob(&c, b"require \"fileinto\";\nkeep;").unwrap();
+        c.execute(
+            "UPDATE blobs SET data = replace(data, 'keep', 'discard') WHERE id = ?1",
+            params![id],
+        )
+        .unwrap();
+        assert_eq!(
+            blob_bytes(&c, id).unwrap().as_deref(),
+            Some(&b"require \"fileinto\";\ndiscard;"[..])
+        );
+    }
+
+    #[test]
+    fn repair_stale_hashes_rehashes_rows_edited_by_raw_sql() {
+        let c = mem();
+        let id = intern_blob(&c, b"require \"fileinto\";\nkeep;").unwrap();
+        c.execute(
+            "UPDATE blobs SET data = replace(data, 'keep', 'discard') WHERE id = ?1",
+            params![id],
+        )
+        .unwrap();
+
+        let repaired = repair_stale_hashes(&c).unwrap();
+        assert_eq!(repaired, 1);
+
+        let expected = blake3::hash(b"require \"fileinto\";\ndiscard;");
+        let stored_hash: Vec<u8> = c
+            .query_row("SELECT hash FROM blobs WHERE id = ?1", params![id], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(stored_hash, expected.as_bytes().as_slice());
+        assert_eq!(
+            blob_bytes(&c, id).unwrap().as_deref(),
+            Some(&b"require \"fileinto\";\ndiscard;"[..])
+        );
+
+        // Second call is a no-op: nothing left with TEXT storage class.
+        assert_eq!(repair_stale_hashes(&c).unwrap(), 0);
+    }
+
+    #[test]
+    fn repair_stale_hashes_skips_rows_that_collide_with_an_existing_blob() {
+        let c = mem();
+        let kept = intern_blob(&c, b"same content").unwrap();
+        let edited = intern_blob(&c, b"will collide").unwrap();
+        c.execute(
+            "UPDATE blobs SET data = 'same content' WHERE id = ?1",
+            params![edited],
+        )
+        .unwrap();
+
+        let repaired = repair_stale_hashes(&c).unwrap();
+        assert_eq!(repaired, 0);
+
+        let edited_hash: Vec<u8> = c
+            .query_row("SELECT hash FROM blobs WHERE id = ?1", params![edited], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(
+            edited_hash,
+            blake3::hash(b"will collide").as_bytes().as_slice(),
+            "colliding row keeps its stale hash for manual resolution"
+        );
+        assert_eq!(
+            blob_bytes(&c, edited).unwrap().as_deref(),
+            Some(&b"same content"[..]),
+            "content is still readable via the TEXT-storage-class tolerance"
+        );
+        assert!(blob_bytes(&c, kept).unwrap().is_some());
     }
 
     #[test]


### PR DESCRIPTION
### Summary
- Adds a `--repair-text-hash` flag (global, so it applies to both `import` and `export`) that re-hashes and normalizes any blob row whose bytes were changed by a raw SQL edit made outside vandelay.
- Off by default — it rewrites archive rows before anything else touches them, so it's opt-in.

### Why
The archive is content-addressed: every blob's id is derived from a BLAKE3 hash of its bytes. That invariant only holds as long as vandelay itself is the one writing the bytes. If someone hand-patches archive data with a raw SQL `UPDATE` — e.g. fixing a broken sieve script or correcting a mis-imported email body — the hash goes stale, and SQLite quietly downgrades that row's `data` column from `BLOB` storage class to `TEXT`, since none of vandelay's own code paths do that. Left alone, a stale hash means the archive's content-addressing is silently wrong: the row's id no longer matches what's actually stored.

### Implementation
- `blob_bytes()` (`src/db/blobs.rs`) now tolerates the `TEXT` storage class on read instead of assuming `BLOB` only.
- A new `repair_stale_hashes()` scans for rows sitting on that non-`BLOB` storage class — which vandelay itself never produces, so it doubles as the marker for "this row was hand-edited" — re-hashes their bytes, and normalizes the column back to `BLOB`.
- Wired into `cli.rs::common_config()`, gated behind `--repair-text-hash`, applied once up front before the archive is handed to any import/export logic.

### Test plan
- Unit tests in `src/db/blobs.rs`:
  - `blob_bytes_tolerates_text_storage_class`
  - `repair_stale_hashes_rehashes_rows_edited_by_raw_sql`
  - `repair_stale_hashes_skips_rows_that_collide_with_an_existing_blob`
- `cargo build`, `cargo clippy --all-targets`, `cargo test` all clean.
